### PR TITLE
MAKE-846: remove line that clears InsecureSkipVerify

### DIFF
--- a/util.go
+++ b/util.go
@@ -38,6 +38,5 @@ func init() {
 
 func GetHTTPClient() *http.Client { return httpClientPool.Get().(*http.Client) }
 func PutHTTPClient(c *http.Client) {
-	c.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify = false
 	httpClientPool.Put(c)
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-846

This field seems to never be set to true and causes a race during the HTTP request the context is cancelled and the HTTP client is put back in the pool.