### PR TITLE
fix parsing of rc version with buildinfo

### DIFF
--- a/versions.go
+++ b/versions.go
@@ -67,7 +67,10 @@ func NewMongoDBVersion(version string) (*MongoDBVersion, error) {
 		v.tag = strings.Join(tagParts[1:], "-")
 
 		if v.isRc {
-			v.rcNumber, err = strconv.Atoi(tagParts[1][2:])
+			// Prerelease may have +buildinfo suffix, like: 1.0.0-rc0+buildinfo
+			rcPart := strings.Split(tagParts[1], "+")
+
+			v.rcNumber, err = strconv.Atoi(rcPart[0][2:])
 			if len(tagParts) > 2 {
 				v.isDev = true
 			}


### PR DESCRIPTION
Hi @tychoish! A parsing error came up when attempting to run curator for libmongocrypt like on this [evergreen patch](https://evergreen.mongodb.com/task/libmongocrypt_ubuntu1604_publish_packages_971c1a899958c427485504a4ba7d8ca1659af30e_19_10_23_17_06_16):

```
./curator repo --config etc/repo_config.yaml --distro ubuntu1604 --edition org --version $pkg_version --arch x86_64 --packages repo+ ./curator repo --config etc/repo_config.yaml --distro ubuntu1604 --edition org --version 1.0.0-rc0+20191023git971c1a8999 --arch x86_64 --packages repo

problem constructing task for building repository: strconv.Atoi: parsing "0+20191023git971c1a8999": invalid syntax
```

I believe the version string `1.0.0-rc0+20191023git971c1a8999` conforms to semver specification. So I was hoping to fix this here (and thereby in curator) to fix that task.

I am not very experienced with Go, but to validate this fix, I tested with this: https://gist.github.com/kevinAlbs/15ca5252ac18853dc11a99e4e54d5de6

